### PR TITLE
Makes IPv4 optional for BGP external connections.

### DIFF
--- a/microovn/frr/bgp/persistance.go
+++ b/microovn/frr/bgp/persistance.go
@@ -35,11 +35,12 @@ func EnsureInterfacesInVrf(ctx context.Context, s state.State) error {
 		}
 		portVrf = strings.TrimSpace(portVrf)
 
-		portIP, err := ovnCmd.VSCtl(ctx, s, "get", "port", port, fmt.Sprintf("external-ids:%s", BgpIfaceIP))
-		if err != nil {
-			allErrors = errors.Join(allErrors, fmt.Errorf("failed to lookup IPv4 address of port '%s': %v", port, err))
-		}
-		portIP = strings.Trim(strings.TrimSpace(portIP), "\"")
+		portIP := ""
+		// portIP, err = ovnCmd.VSCtl(ctx, s, "get", "port", port, fmt.Sprintf("external-ids:%s", BgpIfaceIP))
+		// if err != nil {
+		// 	allErrors = errors.Join(allErrors, fmt.Errorf("failed to lookup IPv4 address of port '%s': %v", port, err))
+		// }
+		// portIP = strings.Trim(strings.TrimSpace(portIP), "\"")
 
 		err = moveInterfaceToVrf(ctx, port, portIP, portVrf)
 		if err != nil {

--- a/microovn/frr/bgp/service.go
+++ b/microovn/frr/bgp/service.go
@@ -70,7 +70,7 @@ func EnableService(ctx context.Context, s state.State, extraConfig *types.ExtraB
 	}
 
 	if extraConfig.Asn != "" {
-		err = startBgpUnnumbered(ctx, extConnections, extraConfig.Vrf, extraConfig.Asn)
+		err = startBgpUnnumbered(ctx, s, extConnections, extraConfig.Vrf, extraConfig.Asn)
 	}
 
 	return err

--- a/tests/test_helper/bats/bgp_data_plane.bats
+++ b/tests/test_helper/bats/bgp_data_plane.bats
@@ -32,10 +32,9 @@ function ping_ovn_int_network_over_bgp_router() {
 
     # Enable BGP redirection and start BGP daemon in OVN chassis
     local host_asn=4210000000
-    local BGP_NET_IP="172.16.10.1/24"
     local vrf="10"
     local vrf_device="ovnvrf$vrf"
-    local external_connections="$OVN_CONTAINER_INT_IFACE:$BGP_NET_IP"
+    local external_connections="$OVN_CONTAINER_INT_IFACE"
 
     echo "# Enabling MicroOVN BGP in $TEST_CONTAINER and configuring BGP (ASN $host_asn)" >&3
     lxc_exec "$TEST_CONTAINER" "microovn enable bgp \


### PR DESCRIPTION
Allows easier enabling of BGP via no longer needing IPv4. This is part of the attempt to get BGP unnumbered working within OVN. This configures the router-id which is generated based off a hash of the logical router port name.